### PR TITLE
西暦で年を返す関数を追加。昭和と平成で比較した場合のmonthsAfterDateのバグを修正

### DIFF
--- a/NSDate-Escort/NSDate+Escort.h
+++ b/NSDate-Escort/NSDate+Escort.h
@@ -143,4 +143,5 @@
 // e.g. 2nd Tuesday of the month == 2
 @property(readonly) NSInteger nthWeekday;
 @property(readonly) NSInteger year;
+@property(readonly) NSInteger gregorianYear;
 @end

--- a/NSDate-Escort/NSDate+Escort.m
+++ b/NSDate-Escort/NSDate+Escort.m
@@ -343,7 +343,7 @@
 }
 
 - (NSInteger)monthsAfterDate:(NSDate *) aDate {
-    NSInteger result = (self.year - aDate.year) * 12 + (self.month - aDate.month);
+    NSInteger result = (self.gregorianYear - aDate.gregorianYear) * 12 + (self.month - aDate.month);
 
     if (result == 0) {
         return 0;
@@ -454,6 +454,13 @@
 - (NSInteger)year {
     NSDateComponents *components = [[NSDate AZ_currentCalendar] components:NSYearCalendarUnit fromDate:self];
     return [components year];
+}
+- (NSInteger)gregorianYear {
+    NSCalendar *currentCalendar = [NSDate AZ_currentCalendar];
+    NSDateComponents *components = [currentCalendar components:NSEraCalendarUnit | NSYearCalendarUnit fromDate:self];
+    components.era = 0;
+    NSDate *date = [currentCalendar dateFromComponents:components];
+    return [date year];
 }
 
 @end


### PR DESCRIPTION
年号によるバグがあった。

和暦において
昭和63年において、date.yearは63と等しくすべき。これは正しく動く
平成元年において、date.yearは1と等しくすべき。これは正しく動く
昭和63年と平成元年の差は1年であるはずだが、実際には-62年を示す。これは内部的でdate.yearを使っているためである。

そこで、gregorianYearを追加した。これは、西暦で年を返すメッセージである。このメッセージを用いて、monthsAfterDateを修正した。
