### PR TITLE
gregorianYearの算出方法にバグが有ったので修正

### DIFF
--- a/NSDate-Escort/NSDate+Escort.m
+++ b/NSDate-Escort/NSDate+Escort.m
@@ -456,11 +456,9 @@
     return [components year];
 }
 - (NSInteger)gregorianYear {
-    NSCalendar *currentCalendar = [NSDate AZ_currentCalendar];
+    NSCalendar *currentCalendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
     NSDateComponents *components = [currentCalendar components:NSEraCalendarUnit | NSYearCalendarUnit fromDate:self];
-    components.era = 0;
-    NSDate *date = [currentCalendar dateFromComponents:components];
-    return [date year];
+    return [components year];
 }
 
 @end


### PR DESCRIPTION
算出するたびにNSCalenderが生成されるので、キャッシュした方がいいかもしれない
