### PR TITLE
Fixed an issue where AZ_DefaultCalendarIdentifier was not thread-safe.

### DIFF
--- a/NSDate-Escort/NSDate+Escort.h
+++ b/NSDate-Escort/NSDate+Escort.h
@@ -7,6 +7,11 @@
 #pragma mark - Setting default calendar
 
 /**
+ Returns the calendarIdentifier of calendars that is used by this library for date calculation.
+ @see setDefaultCalendarIdentifier: for more details.
+ */
++ (NSString *)defaultCalendarIdentifier;
+/**
  Sets the calendarIdentifier of calendars that is used by this library for date calculation.
  You can specify any calendarIdentifiers predefined by NSLocale. If you provide nil, the library uses
  [NSCalendar currentCalendar]. Default value is nil.

--- a/Test/EscortCacheSpec.m
+++ b/Test/EscortCacheSpec.m
@@ -20,7 +20,7 @@ SPEC_BEGIN(EscortCache)
             it(@"should not raise", ^{
                 [[theBlock(^{
                     NSOperationQueue *queue = [[NSOperationQueue alloc] init];
-                    [queue setMaxConcurrentOperationCount:4];
+                    [queue setMaxConcurrentOperationCount:8];
                     NSDate *date = [NSDate date];
                     for (int i = 0; i < 100; i++) {
                         [queue addOperationWithBlock:^{


### PR DESCRIPTION
But basically you should not try changing this value that often from multiple threads. This value should only be set when appropriate timings like user chooses their calendar or something like that...
