### PR TITLE
Made AZ_currentCalendar public.

### DIFF
--- a/NSDate-Escort/NSDate+Escort.h
+++ b/NSDate-Escort/NSDate+Escort.h
@@ -4,8 +4,15 @@
 
 @interface NSDate (Escort)
 
-#pragma mark - Setting default calendar
+#pragma mark - Managing default calendar
 
+/**
+ Returns the current calendar object which is used by this library for date calculation.
+ The returned calendar object is thread-safe since they are instantiated for each different threads.
+ You can specify a type of calendar by providing a calendar identifier to AZ_setDefaultCalendarIdentifier: method. 
+ @see AZ_setDefaultCalendarIdentifier: for more details.
+ */
++ (NSCalendar *)AZ_currentCalendar;
 /**
  Returns the calendarIdentifier of calendars that is used by this library for date calculation.
  @see AZ_setDefaultCalendarIdentifier: for more details.

--- a/NSDate-Escort/NSDate+Escort.m
+++ b/NSDate-Escort/NSDate+Escort.m
@@ -25,7 +25,8 @@ static NSString * AZ_DefaultCalendarIdentifier = nil;
 static NSLock * AZ_DefaultCalendarIdentifierLock = nil;
 static dispatch_once_t AZ_DefaultCalendarIdentifierLock_onceToken;
 
-#pragma mark - private
+#pragma mark - Managing default calendar
+
 + (NSCalendar *)AZ_currentCalendar {
     NSString *key = @"AZ_currentCalendar_";
     NSString *calendarIdentifier = [NSDate AZ_defaultCalendarIdentifier];
@@ -45,7 +46,6 @@ static dispatch_once_t AZ_DefaultCalendarIdentifierLock_onceToken;
     }
     return currentCalendar;
 }
-#pragma mark - Setting default calendar
 + (NSString *)AZ_defaultCalendarIdentifier {
     dispatch_once(&AZ_DefaultCalendarIdentifierLock_onceToken, ^{
         AZ_DefaultCalendarIdentifierLock = [[NSLock alloc] init];
@@ -64,7 +64,9 @@ static dispatch_once_t AZ_DefaultCalendarIdentifierLock_onceToken;
     AZ_DefaultCalendarIdentifier = calendarIdentifier;
     [AZ_DefaultCalendarIdentifierLock unlock];
 }
+
 #pragma mark - Relative dates from the current date
+
 + (NSDate *)dateTomorrow {
     NSTimeInterval timeInterval = [NSDate timeIntervalSinceReferenceDate] + (SECONDS_IN_DAY * 1);
     return [NSDate dateWithTimeIntervalSinceReferenceDate:timeInterval];


### PR DESCRIPTION
This is useful when you want the application-global calendar object for general date calculation. For my app, I want to make sure all date calculations are guaranteed to use NSGregorianCalendar. Also, this calendar is thread-safe as well as fast (cached).
