### PR TITLE
Respect default time zone changes in dateAtStartOfDay end dateAtEndOfDay

### DIFF
--- a/NSDate-Escort/NSDate+Escort.m
+++ b/NSDate-Escort/NSDate+Escort.m
@@ -24,7 +24,7 @@ static dispatch_once_t AZ_DefaultCalendarIdentifierLock_onceToken;
         }
         [dictionary setObject:currentCalendar forKey:key];
     }
-    currentCalendar.timeZone = [NSTimeZone systemTimeZone];
+    currentCalendar.timeZone = [NSTimeZone localTimeZone];
     return currentCalendar;
 }
 
@@ -265,6 +265,7 @@ static dispatch_once_t AZ_DefaultCalendarIdentifierLock_onceToken;
     components.hour = 0;
     components.minute = 0;
     components.second = 0;
+    components.timeZone = calendar.timeZone;
     return [calendar dateFromComponents:components];
 }
 
@@ -274,6 +275,7 @@ static dispatch_once_t AZ_DefaultCalendarIdentifierLock_onceToken;
     components.hour = 23;
     components.minute = 59;
     components.second = 59;
+    components.timeZone = calendar.timeZone;
     return [calendar dateFromComponents:components];
 }
 

--- a/Test/EscortAdjustingDatesSpec.m
+++ b/Test/EscortAdjustingDatesSpec.m
@@ -691,6 +691,37 @@ SPEC_BEGIN(EscortAdjustingDates)
                 [[subject should] equal:expectDate];
             });
         });
+        context(@"when default time zone is changed", ^{
+            __block NSDate *currentDate;
+            beforeEach(^{
+                currentDate = [NSDate AZ_dateByUnit:@{
+                    AZ_DateUnit.year : @2010,
+                    AZ_DateUnit.month : @10,
+                    AZ_DateUnit.day : @10,
+                    AZ_DateUnit.hour : @23,
+                    AZ_DateUnit.minute : @59,
+                    AZ_DateUnit.second : @59,
+                }];
+            });
+            it(@"should return start of day in new time zone", ^{
+                NSTimeZone *initialTimeZone = [NSTimeZone defaultTimeZone];
+                NSTimeZone *GMT = [NSTimeZone timeZoneWithAbbreviation:@"GMT"];
+                assert(initialTimeZone.secondsFromGMT != GMT.secondsFromGMT);
+                
+                [NSTimeZone setDefaultTimeZone:GMT];
+                NSDate *expectDate = [NSDate AZ_dateByUnit:@{
+                    AZ_DateUnit.year : @2010,
+                    AZ_DateUnit.month : @10,
+                    AZ_DateUnit.day : @10,
+                    AZ_DateUnit.hour : @0,
+                    AZ_DateUnit.minute : @0,
+                    AZ_DateUnit.second : @0,
+                }];
+                [[[currentDate dateAtStartOfDay] should] equal:expectDate];
+                
+                [NSTimeZone setDefaultTimeZone:initialTimeZone];
+            });
+        });
     });
     describe(@"-dateAtEndOfDay", ^{
         context(@"when the date is 2010-10-10 00:00:00", ^{
@@ -737,6 +768,37 @@ SPEC_BEGIN(EscortAdjustingDates)
             });
             it(@"should return same date", ^{
                 [[subject should] equal:currentDate];
+            });
+        });
+        context(@"when default time zone is changed", ^{
+            __block NSDate *currentDate;
+            beforeEach(^{
+                currentDate = [NSDate AZ_dateByUnit:@{
+                    AZ_DateUnit.year : @2010,
+                    AZ_DateUnit.month : @10,
+                    AZ_DateUnit.day : @10,
+                    AZ_DateUnit.hour : @0,
+                    AZ_DateUnit.minute : @0,
+                    AZ_DateUnit.second : @0,
+                }];
+            });
+            it(@"should return end of day in new time zone", ^{
+                NSTimeZone *initialTimeZone = [NSTimeZone defaultTimeZone];
+                NSTimeZone *GMTPlus2 = [NSTimeZone timeZoneForSecondsFromGMT:2*3600];
+                assert(initialTimeZone.secondsFromGMT != GMTPlus2.secondsFromGMT);
+                
+                [NSTimeZone setDefaultTimeZone:GMTPlus2];
+                NSDate *expectDate = [NSDate AZ_dateByUnit:@{
+                    AZ_DateUnit.year : @2010,
+                    AZ_DateUnit.month : @10,
+                    AZ_DateUnit.day : @10,
+                    AZ_DateUnit.hour : @23,
+                    AZ_DateUnit.minute : @59,
+                    AZ_DateUnit.second : @59,
+                }];
+                [[[currentDate dateAtEndOfDay] should] equal:expectDate];
+                
+                [NSTimeZone setDefaultTimeZone:initialTimeZone];
             });
         });
     });


### PR DESCRIPTION
This fixes a problem with start/end of day calculation after a time zone of an application is changed. 

Explanation: method` dateFromComponents:` in `NSCalendar` doesn't respect changes to `timeZone` property of a calendar. As a result, when a time zone for an application is changed (using `setDefaultTimeZone:` in `NSTimeZone`), it returns incorrect dates.

The problem almost certainly exists everywhere you use `dateFromComponents:`. I've only fixed two used cases.

This also fixes a change made in `0500572`, where `localTimeZone` should be used instead of `systemTimeZone`.

Explanation: `systemTimeZone` doesn't respect time zone of an application.