### PR TITLE
Fix Unit Test "start of day in new time zone"

### DIFF
--- a/Test/EscortAdjustingDatesSpec.m
+++ b/Test/EscortAdjustingDatesSpec.m
@@ -705,10 +705,17 @@ SPEC_BEGIN(EscortAdjustingDates)
             });
             it(@"should return start of day in new time zone", ^{
                 NSTimeZone *initialTimeZone = [NSTimeZone defaultTimeZone];
-                NSTimeZone *GMT = [NSTimeZone timeZoneWithAbbreviation:@"GMT"];
-                assert(initialTimeZone.secondsFromGMT != GMT.secondsFromGMT);
+                NSTimeZone *newTimeZone = nil;
                 
-                [NSTimeZone setDefaultTimeZone:GMT];
+                BOOL isInitialTimeZoneGMT = ([initialTimeZone.abbreviation isEqualToString:@"GMT"]);
+                if (!isInitialTimeZoneGMT) {
+                    newTimeZone = [NSTimeZone timeZoneWithAbbreviation:@"GMT"];
+                } else {
+                    newTimeZone = [NSTimeZone timeZoneWithAbbreviation:@"PET"];
+                }
+                assert(initialTimeZone.secondsFromGMT != newTimeZone.secondsFromGMT);
+                
+                [NSTimeZone setDefaultTimeZone:newTimeZone];
                 NSDate *expectDate = [NSDate AZ_dateByUnit:@{
                     AZ_DateUnit.year : @2010,
                     AZ_DateUnit.month : @10,


### PR DESCRIPTION
The unit test was failing if the defaultTimeZone was GMT. Now the test
checks if the defaultTimeZone is GMT or not and than a newTimeZone is
chosen between GMT and Peru Time (Standard Time)