### PR TITLE
太陰太陽暦の同月判定が間違っている

### DIFF
--- a/NSDate-Escort/NSDate+Escort.m
+++ b/NSDate-Escort/NSDate+Escort.m
@@ -131,10 +131,9 @@ static dispatch_once_t AZ_DefaultCalendarIdentifierLock_onceToken;
 }
 
 - (BOOL)isSameMonthAsDate:(NSDate * _Nonnull) aDate {
-    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
-    NSDateComponents *componentsSelf = [calendar components:NSCalendarUnitEra | NSCalendarUnitYear | NSCalendarUnitMonth fromDate:self];
-    NSDateComponents *componentsArgs = [calendar components:NSCalendarUnitEra | NSCalendarUnitYear | NSCalendarUnitMonth fromDate:aDate];
-    return (componentsSelf.era == componentsArgs.era && componentsSelf.year == componentsArgs.year && componentsSelf.month == componentsArgs.month);
+    NSDate *dateAtStartSelf = [[self dateAtStartOfMonth] dateAtStartOfDay];
+    NSDate *dateAtStartArgs = [[aDate dateAtStartOfMonth] dateAtStartOfDay];
+    return [dateAtStartSelf isEqualToDate:dateAtStartArgs];
 }
 
 - (BOOL)isThisMonth {
@@ -142,10 +141,9 @@ static dispatch_once_t AZ_DefaultCalendarIdentifierLock_onceToken;
 }
 
 - (BOOL)isSameYearAsDate:(NSDate * _Nonnull) aDate {
-    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
-    NSDateComponents *componentsSelf = [calendar components:NSCalendarUnitEra | NSCalendarUnitYear fromDate:self];
-    NSDateComponents *componentsArgs = [calendar components:NSCalendarUnitEra | NSCalendarUnitYear fromDate:aDate];
-    return (componentsSelf.era == componentsArgs.era && componentsSelf.year == componentsArgs.year);
+    NSDate *dateAtStartSelf = [[self dateAtStartOfYear] dateAtStartOfDay];
+    NSDate *dateAtStartArgs = [[aDate dateAtStartOfYear] dateAtStartOfDay];
+    return [dateAtStartSelf isEqualToDate:dateAtStartArgs];
 }
 
 - (BOOL)isThisYear {

--- a/Test/EscortComparingSpec.m
+++ b/Test/EscortComparingSpec.m
@@ -640,6 +640,35 @@ SPEC_BEGIN(EscortComparingSpec)
                 });
             });
         });
+        context(@"today is 2010-02-13", ^{
+            __block NSDate *currentDate;
+            beforeEach(^{
+                // date at end of year in Chinese
+                currentDate = [NSDate AZ_dateByUnit:@{
+                    AZ_DateUnit.year : @2010,
+                    AZ_DateUnit.month : @2,
+                    AZ_DateUnit.day : @13,
+                }];
+                [FakeDateUtil stubCurrentDate:currentDate];
+                
+                NSCalendar *chineseCalendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierChinese];
+                [NSDate stub:@selector(AZ_currentCalendar) andReturn:chineseCalendar];
+            });
+            context(@"1 days ago", ^{
+                __block NSDate *_1daysAgo;
+                beforeEach(^{
+                    // date at start of year in Chinese
+                    NSCalendar *calendar = [NSCalendar currentCalendar];
+                    NSDateComponents *oneMonthComponents = [[NSDateComponents alloc] init];
+                    oneMonthComponents.day = 1;
+                    _1daysAgo = [calendar dateByAddingComponents:oneMonthComponents toDate:currentDate options:0];
+                });
+                it(@"should be true", ^{
+                    BOOL match = [currentDate isSameYearAsDate:_1daysAgo];
+                    [[theValue(match) should] beNo];
+                });
+            });
+        });
     });
     describe(@"-isThisMonth", ^{
         __block NSDate *currentDate;
@@ -743,6 +772,36 @@ SPEC_BEGIN(EscortComparingSpec)
             it(@"should be false", ^{
                 BOOL match = [currentDate isSameYearAsDate:nextYear];
                 [[theValue(match) should] beNo];
+            });
+        });
+        
+        context(@"today is 2010-02-13", ^{
+            __block NSDate *currentDate;
+            beforeEach(^{
+                // date at end of year in Chinese
+                currentDate = [NSDate AZ_dateByUnit:@{
+                    AZ_DateUnit.year : @2010,
+                    AZ_DateUnit.month : @2,
+                    AZ_DateUnit.day : @13,
+                }];
+                [FakeDateUtil stubCurrentDate:currentDate];
+                
+                NSCalendar *chineseCalendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierChinese];
+                [NSDate stub:@selector(AZ_currentCalendar) andReturn:chineseCalendar];
+            });
+            context(@"1 days ago", ^{
+                __block NSDate *_1daysAgo;
+                beforeEach(^{
+                    // date at start of year in Chinese
+                    NSCalendar *calendar = [NSCalendar currentCalendar];
+                    NSDateComponents *oneMonthComponents = [[NSDateComponents alloc] init];
+                    oneMonthComponents.day = 1;
+                    _1daysAgo = [calendar dateByAddingComponents:oneMonthComponents toDate:currentDate options:0];
+                });
+                it(@"should be true", ^{
+                    BOOL match = [currentDate isSameMonthAsDate:_1daysAgo];
+                    [[theValue(match) should] beNo];
+                });
             });
         });
     });


### PR DESCRIPTION
下記のコードのテストが通らない

```
context(@"today is 2010-02-13", ^{
            __block NSDate *currentDate;
            beforeEach(^{
                currentDate = [NSDate AZ_dateByUnit:@{ // 中国暦で年の終わり
                    AZ_DateUnit.year : @2010,
                    AZ_DateUnit.month : @2,
                    AZ_DateUnit.day : @13,
                }];
                [FakeDateUtil stubCurrentDate:currentDate];
                
                NSCalendar *chineseCalendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierChinese];
                [NSDate stub:@selector(AZ_currentCalendar) andReturn:chineseCalendar];
            });
            context(@"1 days ago", ^{
                __block NSDate *_1daysAgo;
                beforeEach(^{ // 中国暦で年の始まり
                    NSCalendar *calendar = [NSCalendar currentCalendar];
                    NSDateComponents *oneMonthComponents = [[NSDateComponents alloc] init];
                    oneMonthComponents.day = 1;
                    _1daysAgo = [calendar dateByAddingComponents:oneMonthComponents toDate:currentDate options:0];
                });
                it(@"should be true", ^{
                    BOOL match = [currentDate isSameMonthAsDate:_1daysAgo];
                    [[theValue(match) should] beNo];
                });
            });
        });
```

原因は和暦とグレゴリオ暦のように年は違っても、月と日が同じであるので、和暦をグレゴリオ暦として計算しても問題はなかったが、中国暦はそもそも年の始まりからして違うためグレゴリオ暦に変換して計算している現状の実装では正しく動作しない。